### PR TITLE
Creación de un excluir.bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Listado de cambios:
 
 ## Inicio rápido
 
-Para comenzar a trabajar con las herramientas hay que establecer un **identificador** para la imagen y **descomprimir**. Esto solo se hará la primera vez
+Para empezar a trabajar con las herramientas, antes de nada hay que añadir la carpeta a las exclusiones del antivirus de windows. Para ello ejecuta desde la terminal el script `utilidades\excluir.bat`. 
+Se puede ejecutar de 3 formas diferentes:
+
+1. `excluir.bat`: Excluye tu directorio actual de trabajo
+2. `excluir.bat -sd`: Excluye el directorio del script
+3. `excluir.bat absolute_path`: Excluye el directorio que le pases ¡Tiene que ser una ruta absoluta!
+
+Una vez excluido, hay que establecer un **identificador** para la imagen y **descomprimir**. Esto solo se hará la primera vez
 
 1. ```echo abcd > id.txt``` (Cuidado con los espacios extra en windows)
 2. ```utilidades\descomprimir.bat```

--- a/excluir.bat
+++ b/excluir.bat
@@ -1,0 +1,31 @@
+@echo off
+
+:: Guardar el directorio actual
+set "folder=%~dp0"
+set "folder=%folder:~0,-1%"
+
+:: Comprobar los argumentos
+if "%~1"=="-c" (
+    set "folder=%CD%"
+) else if not "%~1"=="" (
+    set "folder=%~1"
+)
+
+:: Comprobar si se esta ejecutando como administrador
+net session >nul 2>&1
+if %errorLevel% NEQ 0 (
+    echo Se requieren privilegios de administrador.
+    echo Iniciando con privilegios elevados...
+
+    :: Relanzar el script con permisos de administrador y pasar el directorio actual
+    powershell -Command "Start-Process cmd -ArgumentList '/c \"\"%~dpnx0\" \"%folder%\"\"' -Verb RunAs"
+
+    :: Salir si no se ha dado los permisos
+    exit /b
+)
+
+:: Llamar a PowerShell para agregar la exclusion
+PowerShell -Command "Add-MpPreference -ExclusionPath '%folder%'"
+
+echo La carpeta %folder% ha sido agregada a las exclusiones de Windows Defender.
+pause

--- a/utilidades/excluir.bat
+++ b/utilidades/excluir.bat
@@ -1,14 +1,17 @@
 @echo off
 
 :: Guardar el directorio actual
-set "folder=%~dp0"
-set "folder=%folder:~0,-1%"
+set "folder=%CD%"
 
 :: Comprobar los argumentos
-if "%~1"=="-c" (
-    set "folder=%CD%"
+if "%~1"=="-sd" (
+    set "folder=%~dp0"
 ) else if not "%~1"=="" (
     set "folder=%~1"
+)
+
+if "%folder:~-1%"=="\" (
+    set "folder=%folder:~0,-1%"
 )
 
 :: Comprobar si se esta ejecutando como administrador


### PR DESCRIPTION
# excluir.bat

Script que uso para añadir la carpeta de trabajo a las exclusiones del antivirus de windows.

## Uso

Cuando ejecutas el script te pide permisos de administrador si no los tienes. Cuando los aceptas se añade la carpeta a exclusiones

- Script sin parametros: Excluye la carpeta en la que se encuentra el script
- Script `-c`: Excluye el directorio actual de trabajo
- Script `custom_path`: Excluye la ruta pasada (Solo testeado con rutas absolutas)

---

Testeado en escritorio remoto windows 10